### PR TITLE
Update the lease agreement in eureka

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,8 @@ spring:
 eureka:
   instance:
     prefer-ip-address: true
+    leaseRenewalIntervalInSeconds: 30
+    lease-expiration-duration-in-seconds: 60
   client:
     register-with-eureka: false
     fetch-registry: false


### PR DESCRIPTION
The instances lease was not expiring when they go down for a new deploy this will change the interval in which the instance will last with a threshold of register pings per min.